### PR TITLE
Drop traces of osm_bb() function

### DIFF
--- a/tests/testthat/test-osm_bb.R
+++ b/tests/testthat/test-osm_bb.R
@@ -1,8 +1,0 @@
-# test_that("OSM bounding box is correctly retreived from Overpass API", {
-#   skip_on_ci()
-#
-#   bb <- CRiSp::osm_bb("Bucharest")
-#   expected <- matrix(c(25.966674, 44.334247, 26.225577, 44.541396),
-#                      ncol = 2, dimnames = list(c("x", "y"), c("min", "max")))
-#   expect_equal(bb, expected)
-# })


### PR DESCRIPTION
This test was left over from `osm_bb()`. I removed that function previously and now the commented-out test with it. `R CMD check` should pass now.