### PR TITLE
Remove filter_network from segmentation vignette

### DIFF
--- a/R/network.R
+++ b/R/network.R
@@ -296,7 +296,6 @@ nearest_node <- function(network, target) {
 #' @param target The target geometry
 #'
 #' @return A spatial network object
-#' @export
 filter_network <- function(network, target) {
   network |>
     tidygraph::activate("nodes") |>

--- a/vignettes/corridor-segmentation.Rmd
+++ b/vignettes/corridor-segmentation.Rmd
@@ -42,7 +42,8 @@ network_filtered_before <- rbind(streets, railways) |>
   as_network()
 
 # Build combined street and railway network
-network_filtered_after <- rbind(bucharest_osm$streets, bucharest_osm$railways) |>
+network_filtered_after <- rbind(bucharest_osm$streets,
+                                bucharest_osm$railways) |>
   as_network() |>
   tidygraph::activate("nodes") |>
   tidygraph::filter(sfnetworks::node_intersects(corridor_buffer)) |>

--- a/vignettes/corridor-segmentation.Rmd
+++ b/vignettes/corridor-segmentation.Rmd
@@ -27,23 +27,40 @@ To demonstrate this as a separate step, we will use the `bucharest_delineation$c
 
 We first prepare the network and select all the streets and railways that cover the river corridor plus a small buffer region (see also `vignette("network-preparation")`):
 
-```{r}
+```{r network, warning=FALSE}
+# Add a 100 meter buffer region around the corridor
+corridor_buffer <- sf::st_buffer(bucharest_delineation$corridor, 500)
+
+# Filter the streets and railwayas to the buffer area
+streets <- bucharest_osm$streets |>
+  sf::st_filter(corridor_buffer, .predicate = sf::st_intersects)
+railways <- bucharest_osm$railways |>
+  sf::st_filter(corridor_buffer, .predicate = sf::st_intersects)
+
 # Build combined street and railway network
-network <- rbind(bucharest_osm$streets, bucharest_osm$railways) |>
+network_filtered_before <- rbind(streets, railways) |>
   as_network()
 
-# Add a 100 meter buffer region to the corridor
-corridor_buffer <- sf::st_buffer(bucharest_delineation$corridor, 100)
-
-# Filter the network to the area of interest
-network_filtered <- filter_network(network, corridor_buffer)
+# Build combined street and railway network
+network_filtered_after <- rbind(bucharest_osm$streets, bucharest_osm$railways) |>
+  as_network() |>
+  tidygraph::activate("nodes") |>
+  tidygraph::filter(sfnetworks::node_intersects(corridor_buffer)) |>
+  # keep only the main connected component of the network
+  tidygraph::activate("nodes") |>
+  dplyr::filter(tidygraph::group_components() == 1)
 ```
 
 We then delineate segments in the corridor. The algorithm spits the corridor using river-crossing transversal edges that form continuous lines in the network:
 
-```{r}
-segmented_corridor <- delineate_segments(bucharest_delineation$corridor,
-                                         network_filtered,
-                                         bucharest_osm$river_centerline)
+```{r segmentation, warning=FALSE}
+segmented_corridor_1 <- delineate_segments(bucharest_delineation$corridor,
+                                           network_filtered_before,
+                                           bucharest_osm$river_centerline)
+segmented_corridor_2 <- delineate_segments(bucharest_delineation$corridor,
+                                           network_filtered_after,
+                                           bucharest_osm$river_centerline)
+plot(segmented_corridor_1, border = "orange", lwd = 3)
+plot(segmented_corridor_2, add = TRUE, border = "blue")
 ```
 

--- a/vignettes/corridor-segmentation.Rmd
+++ b/vignettes/corridor-segmentation.Rmd
@@ -28,40 +28,28 @@ To demonstrate this as a separate step, we will use the `bucharest_delineation$c
 We first prepare the network and select all the streets and railways that cover the river corridor plus a small buffer region (see also `vignette("network-preparation")`):
 
 ```{r network, warning=FALSE}
-# Add a 100 meter buffer region around the corridor
+# Add a buffer region around the corridor
 corridor_buffer <- sf::st_buffer(bucharest_delineation$corridor, 500)
 
 # Filter the streets and railwayas to the buffer area
 streets <- bucharest_osm$streets |>
-  sf::st_filter(corridor_buffer, .predicate = sf::st_intersects)
+  sf::st_filter(corridor_buffer, .predicate = sf::st_covered_by)
 railways <- bucharest_osm$railways |>
-  sf::st_filter(corridor_buffer, .predicate = sf::st_intersects)
+  sf::st_filter(corridor_buffer, .predicate = sf::st_covered_by)
 
 # Build combined street and railway network
-network_filtered_before <- rbind(streets, railways) |>
+network_filtered <- rbind(streets, railways) |>
   as_network()
 
-# Build combined street and railway network
-network_filtered_after <- rbind(bucharest_osm$streets,
-                                bucharest_osm$railways) |>
-  as_network() |>
-  tidygraph::activate("nodes") |>
-  tidygraph::filter(sfnetworks::node_intersects(corridor_buffer)) |>
-  # keep only the main connected component of the network
-  tidygraph::activate("nodes") |>
-  dplyr::filter(tidygraph::group_components() == 1)
 ```
 
 We then delineate segments in the corridor. The algorithm spits the corridor using river-crossing transversal edges that form continuous lines in the network:
 
 ```{r segmentation, warning=FALSE}
-segmented_corridor_1 <- delineate_segments(bucharest_delineation$corridor,
-                                           network_filtered_before,
-                                           bucharest_osm$river_centerline)
-segmented_corridor_2 <- delineate_segments(bucharest_delineation$corridor,
-                                           network_filtered_after,
-                                           bucharest_osm$river_centerline)
-plot(segmented_corridor_1, border = "orange", lwd = 3)
-plot(segmented_corridor_2, add = TRUE, border = "blue")
+segmented_corridor <- delineate_segments(bucharest_delineation$corridor,
+                                         network_filtered,
+                                         bucharest_osm$river_centerline)
+plot(network_filtered)
+plot(segmented_corridor, border = "orange", lwd = 3, add = TRUE)
 ```
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Before submitting a Pull Request, please ensure you've read the CRiSp
[Contributing Guide](https://cityriverspaces.github.io/CRiSp/CONTRIBUTING.html)
and [Code of Conduct](https://cityriverspaces.github.io/CRiSp/CODE_OF_CONDUCT.html)
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR removes `filter_network()` from the list of exported functions, as it was only used in the `corridor-segmentation` vignette.

## Related Issues

<!--
See [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related Issue #89 
- Closes #89 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [ ] Yes
