### PR TITLE
Fix corridor delineation and segmentation 

### DIFF
--- a/R/corridor.R
+++ b/R/corridor.R
@@ -9,6 +9,8 @@
 #'   centerline
 #' @param river_surface A simple feature geometry representing the river surface
 #' @param aoi Area of interest as sf object or bbox
+#' @param max_width (Approximate) maximum width of the regions considered on the
+#'   two river banks
 #' @param initial_method The method employed to define the initial river
 #'   corridor geometry. See [initial_corridor()] for the available methods
 #' @param buffer Buffer region to add to the river geometry to setup the initial
@@ -24,8 +26,9 @@
 #' @return A simple feature geometry representing the river corridor
 #' @export
 delineate_corridor <- function(
-  network, river_centerline, river_surface, aoi, initial_method = "valley",
-  buffer = NULL, dem = NULL, max_iterations = 10, capping_method = "direct"
+  network, river_centerline, river_surface, aoi = NULL, max_width = 2500,
+  initial_method = "valley", buffer = NULL, dem = NULL, max_iterations = 10,
+  capping_method = "direct"
 ) {
   # Drop all attributes of river centerline and surface but the geometries
   river_centerline <- sf::st_geometry(river_centerline)
@@ -37,11 +40,15 @@ delineate_corridor <- function(
                                     buffer = buffer, dem = dem,
                                     bbox = as_bbox(aoi))
 
-  # Pick the corridor end points
-  end_points <- corridor_end_points(river_centerline, network, aoi = aoi)
+  # Build river network in the defined area of interest
+  river_network <- build_river_network(river_centerline, aoi = aoi)
 
-  # Split the area of interest along the river centerline
-  regions <- split_aoi(aoi, river_centerline)
+  # Pick the corridor end points as the two furthest crossings between the
+  # spatial network and the river
+  end_points <- corridor_end_points(river_network, network)
+
+  # Define the spatial regions corresponding to the two river banks
+  regions <- get_river_banks(river_network, max_width)
 
   # Determine the initial corridor edges by splitting the initial corridor
   # boundary through the just determined regions
@@ -99,34 +106,27 @@ initial_corridor <- function(
   }
 }
 
-#' Find the corridor end points.
+#' Build a spatial network from the river center spatial features
 #'
-#' Determine the extremes (start and end point) of the river corridor
-#' using the river center line and the spatial network used for the delineation.
-#' The end points are selected as the most external river crossing edges of the
-#' network within the area of interest. If the river intersects the
-#' area of interest multiple times, only the longest intersecting segment is
-#' considered here.
+#' If an area of interest (aoi) is provided, only the river segments that
+#' intersects it are considered. If the river intersects the area of interest
+#' multiple times, only the longest intersecting segment will be considered.
 #'
 #' @param river A simple feature geometry representing the river centerline
-#' @param network The spatial network used for the delineation, either provided
-#'   as an [`sfnetworks::sfnetwork`] or as an [`sf::sf`]/[`sf::sfc`] object
-#'   (edges only)
-#' @param aoi Area of interest, provided as a bounding box or as polygon. If not
-#'   given, it is taken as the bounding box of the spatial network
+#' @param aoi Area of interest, provided as a bounding box or as a polygon.
 #'
-#' @return A simple feature geometry including a pair of points
-corridor_end_points <- function(river, network, aoi = NULL) {
-  # Only consider the edges of the spatial network
-  spat_net_edges <- sf::st_geometry(sf::st_as_sf(network, "edges"))
+#' @return A [`sfnetworks::sfnetwork`] object
+build_river_network <- function(river, aoi = NULL) {
+  # Clip the river geometry using the area of interest (if provided)
+  if (!is.null(aoi)) {
+    aoi <- as_sfc(aoi)
+    river <- sf::st_intersection(river, aoi)
+  }
 
-  # Set area of interest as a polygon, even if not defined
-  if (is.null(aoi)) aoi <- sf::st_bbox(spat_net_edges)
-  aoi <- as_sfc(aoi)
-
-  # Clip the river geometry using the area of interest. This might lead to
-  # multiple river segments
-  river_segments <- sf::st_intersection(aoi, sf::st_cast(river, "LINESTRING"))
+  # The river might consist of a multilinestring, or clipping the river using
+  # the area of interest might have lead to multiple segments - cast these into
+  # linestring features
+  river_segments <- sfheaders::sfc_cast(river, "LINESTRING")
 
   # Build a spatial network using the river segments and select the connected
   # component with overall longest edge length
@@ -135,56 +135,72 @@ corridor_end_points <- function(river, network, aoi = NULL) {
   sum_edge_lengths <- function(x) sum(sf::st_length(sf::st_as_sf(x, "edges")))
   edge_lengths <- sapply(components, sum_edge_lengths)
   river_network <- components[[which.max(edge_lengths)]]
-  river_network <- clean_network(river_network)
+  river_network <- clean_network(river_network, simplify = FALSE)  # keep loops
+}
+
+#' Find the corridor end points.
+#'
+#' Determine the extremes (end points) of the river corridor using the network
+#' built from the river center line features (see [`build_river_network()`] and
+#' the spatial network used for the delineation. The end points are selected as
+#' the two furthest river crossings of the spatial network.
+#'
+#' @param river_network A [`sfnetworks::sfnetwork`] object representing the
+#'   river centerline
+#' @param spatial_network A [`sfnetworks::sfnetwork`] object representing the
+#'   spatial network used for the delineation
+#'
+#' @return A simple feature geometry including a pair of points
+corridor_end_points <- function(river_network, spatial_network) {
+  # Only consider the edges of the spatial network
+  spat_network_edges <- sf::st_geometry(sf::st_as_sf(spatial_network, "edges"))
 
   # Find intersections with the spatial network, and add these points as nodes
   # to the river network. These nodes are the candidates corridor end points
   river_network_edges <- sf::st_geometry(sf::st_as_sf(river_network, "edges"))
-  intersections <- sf::st_intersection(river_network_edges, spat_net_edges)
+  intersections <- sf::st_intersection(river_network_edges, spat_network_edges)
   river_network <- sfnetworks::st_network_blend(river_network, intersections)
   nodes <- nearest_node(river_network, intersections)
 
-  # Pick a reference point on the selected river segment, either up- or down-
-  # stream from all crossings. Pick this as the closest node to the aoi boundary
-  reference <- nearest_node(river_network, sf::st_boundary(aoi))
-
-  # Compute the network distance from the reference node to all candidate end
-  # points. The closest and furthest nodes are selected as corridor end points
+  # Compute the network distance between all the candidate end points. The ones
+  # that are furthest away from each others are selected as corridor end points
   river_network <- add_weights(river_network, weight_name = "weight")
-  distances <- sfnetworks::st_network_cost(river_network, from = reference,
+  distances <- sfnetworks::st_network_cost(river_network, from = nodes,
                                            to = nodes, weights = "weight")
-  end_points <- c(nodes[which.min(distances[1, ])],
-                  nodes[which.max(distances[1, ])])
+
+  indices <- which(distances == max(distances), arr.ind = TRUE)[1, ]
+  end_points <- c(nodes[indices["row"]], nodes[indices["col"]])
   if (end_points[1] == end_points[2]) {
     stop("Corridor start- and end-points coincide!")
   }
   end_points
 }
 
-#' Split the area of interest (AoI) by a river.
+#' Draw the regions corresponding to the two river banks
 #'
-#' Return the fragments produced. If more than two fragments are obtained, only
-#' return the two largest fragments.
+#' These are constructed as single-sided buffers around the river geometry (see
+#' [`river_buffer()`] for the implementation and refinement steps).
 #'
-#' @param bbox Bounding box defining the extent of the area of interest
-#' @param river A simple feature geometry representing the river centerline
-#'
-#' @return A simple feature geometry set of two areas of interest
-#' @importFrom rlang .data
-split_aoi <- function(bbox, river) {
-  regions <- split_by(as_sfc(bbox), river)
-
-  if (length(regions) > 2) {
-    # Sort fragments according to area in descending order
-    regions_sorted <- sf::st_as_sf(regions) |>
-      dplyr::mutate(area = sf::st_area(regions)) |>
-      dplyr::arrange(-.data$area)
-
-    # Return the geometries of the two largest fragments
-    sf::st_geometry(regions_sorted[1:2, ])
-  } else {
-    regions
+#' @param river River spatial features provided as a [`sfnetworks::sfnetwork`]
+#'   or [`sf::sf`]/[`sf::sfc`] object.
+#' @param width (Approximate) width of the regions
+#' @return A [`sf::sfc`] object with two polygon features
+get_river_banks <- function(river, width) {
+  if (inherits(river, "sfnetwork")) {
+    river <- sf::st_as_sf(river, "edges")
   }
+  river <- sf::st_geometry(river)
+
+  # Simplify river features by merging consecutive segments. Linestrings are
+  # also uniformly redirected, which should be important for the single-sided
+  # buffering that is carried out next
+  river_merged <- sf::st_cast(sf::st_union(river), "MULTILINESTRING")
+  river_merged <- sf::st_line_merge(river_merged)
+  river_segments <- sfheaders::sfc_cast(river_merged, "LINESTRING")
+
+  # Define the two river bank regions as single-sided buffers
+  c(river_buffer(river_segments, width, side = "right"),
+    river_buffer(river_segments, width, side = "left"))
 }
 
 #' Identify the initial edges of the river corridor

--- a/R/delineate.R
+++ b/R/delineate.R
@@ -74,8 +74,8 @@ delineate <- function(
     force_download = force_download
   )
 
-  # Get the bounding box and (if not provided) the CRS
-  if (is.null(crs)) crs <- get_utm_zone(osm_data$aoi)
+  # If not provided, determine the CRS
+  if (is.null(crs)) crs <- get_utm_zone(osm_data$bb)
 
   if (corridor) {
 

--- a/R/delineate.R
+++ b/R/delineate.R
@@ -78,11 +78,15 @@ delineate <- function(
   if (is.null(crs)) crs <- get_utm_zone(osm_data$bb)
 
   if (corridor) {
+    # For the corridor delineation, the area of interest (aoi) is the one used
+    # to retrieve the network datasets (streets and railways), project to CRS
+    aoi <- reproject(osm_data$aoi_network, crs)
 
     # If using the valley method, and the DEM is not provided, retrieve dataset
+    # on a larger aoi to limit edge effects while determining the valley
     if (initial_method == "valley" && is.null(dem)) {
-      aoi_buff <- buffer(osm_data$aoi, dem_buffer)
-      dem <- get_dem(aoi_buff, crs = crs, force_download = force_download, ...)
+      aoi_dem <- buffer(osm_data$aoi_network, dem_buffer)
+      dem <- get_dem(aoi_dem, crs = crs, force_download = force_download, ...)
     }
 
     # Set up the combined street and rail network for the delineation
@@ -90,11 +94,11 @@ delineate <- function(
     network <- as_network(network_edges)
 
     # Run the corridor delineation on the spatial network
-    aoi_repr <- reproject(osm_data$aoi, crs)
     corridor <- delineate_corridor(
-      network, osm_data$river_centerline, osm_data$river_surface, aoi_repr,
-      initial_method = initial_method, buffer = initial_buffer, dem = dem,
-      max_iterations = max_iterations, capping_method = capping_method
+      network, osm_data$river_centerline, osm_data$river_surface, aoi = aoi,
+      max_width = network_buffer, initial_method = initial_method,
+      buffer = initial_buffer, dem = dem, max_iterations = max_iterations,
+      capping_method = capping_method
     )
   } else {
     corridor <- NULL

--- a/R/network.R
+++ b/R/network.R
@@ -142,24 +142,26 @@ calc_rolling_sum <- function(x, n = 2) {
 #'
 # nolint start
 #' Subdivide edges by [adding missing nodes](https://luukvdmeer.github.io/sfnetworks/articles/sfn02_preprocess_clean.html#subdivide-edges),
-#' simplify the network (see [`simplify_network()`]), remove
+#' (optionally) simplify the network (see [`simplify_network()`]), remove
 #' [pseudo-nodes](https://luukvdmeer.github.io/sfnetworks/articles/sfn02_preprocess_clean.html#smooth-pseudo-nodes),
 #' and discard all but the main connected component.
 # nolint end
 #'
 #' @param network A network object
+#' @param simplify Whether
 #'
 #' @return A cleaned network object
 #' @export
-clean_network <- function(network) {
-  network |>
-    # subdivide edges by adding missing nodes
-    tidygraph::convert(sfnetworks::to_spatial_subdivision, .clean = TRUE) |>
-    # run simplification steps
-    simplify_network() |>
-    # remove pseudo-nodes
-    tidygraph::convert(sfnetworks::to_spatial_smooth, .clean = TRUE) |>
-    # keep only the main connected component of the network
+clean_network <- function(network, simplify = TRUE) {
+  # subdivide edges by adding missing nodes
+  net <- tidygraph::convert(network, sfnetworks::to_spatial_subdivision,
+                            .clean = TRUE)
+  # run simplification steps
+  if (simplify) net <- simplify_network(net)
+  # remove pseudo-nodes
+  net <- tidygraph::convert(net, sfnetworks::to_spatial_smooth, .clean = TRUE)
+  # keep only the main connected component of the network
+  net |>
     tidygraph::activate("nodes") |>
     dplyr::filter(tidygraph::group_components() == 1)
 }

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -226,7 +226,9 @@ get_osm_river <- function(bb, river_name, crs = NULL, force_download = FALSE) {
   river_centerline <- osmdata_as_sf("waterway", "river", bb,
                                     force_download = force_download)
   river_centerline <- river_centerline$osm_multilines |>
-    dplyr::filter(.data$name == river_name) |>
+    # filter using any of the "name" columns (matching different languages)
+    dplyr::filter(dplyr::if_any(dplyr::matches("name"),
+                                \(x) x == river_name)) |>
     # the query can return more features than actually intersecting the bb
     sf::st_filter(sf::st_as_sfc(bb), .predicate = sf::st_intersects) |>
     sf::st_geometry()

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -112,21 +112,29 @@ get_osmdata <- function(
 
   # Retrieve streets and railways based on the aoi
   if (!is.null(network_buffer)) {
-    aoi <- get_river_aoi(river, bb, buffer_distance = network_buffer)
-    osm_data <- append(osm_data, list(aoi = aoi))
+    aoi_network <- get_river_aoi(river$centerline, bb,
+                                 buffer_distance = network_buffer)
     osm_data <- append(osm_data, list(
-      streets = get_osm_streets(aoi, crs = crs, force_download = force_download)
+      aoi_network = reproject(aoi_network, crs)
     ))
     osm_data <- append(osm_data, list(
-      railways = get_osm_railways(aoi, crs = crs,
+      streets = get_osm_streets(aoi_network, crs = crs,
+                                force_download = force_download)
+    ))
+    osm_data <- append(osm_data, list(
+      railways = get_osm_railways(aoi_network, crs = crs,
                                   force_download = force_download)
     ))
   }
 
   # Retrieve buildings based on a different aoi
   if (!is.null(buildings_buffer)) {
+    river <- c(river$centerline, river$surface)
     aoi_buildings <- get_river_aoi(river, bb,
                                    buffer_distance = buildings_buffer)
+    osm_data <- append(osm_data, list(
+      aoi_buildings = reproject(aoi_buildings, crs)
+    ))
     osm_data <- c(osm_data, list(
       buildings = get_osm_buildings(aoi_buildings, crs = crs,
                                     force_download = force_download)

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -358,36 +358,22 @@ get_osm_buildings <- function(aoi, crs = NULL, force_download = FALSE) {
   buildings
 }
 
-#' Get an area of interest (aoi) around a river, cropping to the bounding box of
-#' the city
+#' Get an area of interest (AoI) around a river, cropping to the bounding box of
+#' a city
 #'
-#' @param river A list with the river centreline and surface
+#' @param river A simple feature geometry representing the river
 #' @param city_bbox Bounding box around the city
 #' @param buffer_distance Buffer size around the river
-#' @return An sf or bbox object
+#' @return An sf object in lat/lon coordinates
 #' @export
-#' @importFrom rlang !! sym
 #'
 #' @examples
 #' bb <- get_osm_bb("Bucharest")
 #' river <- get_osm_river(bb, "Dâmbovița")
 #' get_river_aoi(river, bb, buffer_distance = 100)
-get_river_aoi <- function(river, city_bbox, buffer_distance = NULL) {
-  river <- c(river$centerline, river$surface)
-
+get_river_aoi <- function(river, city_bbox, buffer_distance) {
   # Make sure crs are the same for cropping with bb
   river <- sf::st_transform(river, sf::st_crs(city_bbox))
 
-  if (is.null(buffer_distance)) {
-    aoi <- sf::st_union(river) |>
-      sf::st_crop(city_bbox) |>
-      as_bbox()
-  } else {
-    aoi <- river_buffer(
-      river, buffer_distance, bbox = city_bbox
-    )
-  }
-
-  aoi
-
+  river_buffer(river, buffer_distance, bbox = city_bbox)
 }

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -104,6 +104,7 @@ get_osmdata <- function(
   )
 
   osm_data <- list(
+    bb = bb,
     boundary = boundary,
     river_centerline = river$centerline,
     river_surface = river$surface

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -231,7 +231,8 @@ get_osm_river <- function(bb, river_name, crs = NULL, force_download = FALSE) {
                                 \(x) x == river_name)) |>
     # the query can return more features than actually intersecting the bb
     sf::st_filter(sf::st_as_sfc(bb), .predicate = sf::st_intersects) |>
-    sf::st_geometry()
+    sf::st_geometry() |>
+    sf::st_union()
 
   # Get the river surface
   river_surface <- osmdata_as_sf("natural", "water", bb,

--- a/R/sf.R
+++ b/R/sf.R
@@ -22,6 +22,12 @@ as_sfc <- function(x) {
 }
 
 #' @noRd
+find_largest <- function(geometry) {
+  area <- sf::st_area(geometry)
+  which.max(area)
+}
+
+#' @noRd
 find_smallest <- function(geometry) {
   area <- sf::st_area(geometry)
   which.min(area)

--- a/R/utils.R
+++ b/R/utils.R
@@ -58,8 +58,9 @@ as_bbox <- function(x) {
 #'
 #' @param obj A sf object
 #' @param buffer_distance Buffer distance in meters
+#' @param ... Optional parameters passed on to [`sf::st_buffer()`]
 #' @return Expanded sf object
-buffer <- function(obj, buffer_distance) {
+buffer <- function(obj, buffer_distance, ...) {
   is_obj_longlat <- sf::st_is_longlat(obj)
   dst_crs <- sf::st_crs(obj)
   # check if obj is a bbox
@@ -69,7 +70,7 @@ buffer <- function(obj, buffer_distance) {
     crs_meters <- get_utm_zone(obj)
     obj <- sf::st_transform(obj, crs_meters)
   }
-  expanded_obj <- sf::st_buffer(obj, buffer_distance)
+  expanded_obj <- sf::st_buffer(obj, buffer_distance, ...)
   if (is_obj_longlat) {
     expanded_obj <- sf::st_transform(expanded_obj, dst_crs)
   }


### PR DESCRIPTION
This PR introduces few changes that allow the corridor delineation and segmentation to succeed (i.e. succesfully complete) on all the cities considered in https://github.com/CityRiverSpaces/CRiSp-demo-material/blob/main/scripts/generate-corridor.R (plus Paris and Berlin).

As main change: for the corridor delineation, we relied so far on the river centerline splitting a the area of interest (AoI) in two parts to define the two river banks where to look for edges. This approach was not robust enough, and even trying to build the AoI built as a "flat" buffer region around the same river did not work fine due to numerical reasons. Here, I suggest to use instead single-sided buffers build from the river centerline to bypass the issue. 