### PR TITLE
Do not crop river_surface

### DIFF
--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -237,7 +237,6 @@ get_osm_river <- function(bb, river_name, crs = NULL, force_download = FALSE) {
     sf::st_as_sf() |>
     # natural:water retrieved some invalid polygons, fix these
     sf::st_make_valid() |>
-    sf::st_crop(bb) |>
     sf::st_filter(river_centerline, .predicate = sf::st_intersects) |>
     sf::st_union()
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Before submitting a Pull Request, please ensure you've read the CRiSp
[Contributing Guide](https://cityriverspaces.github.io/CRiSp/CONTRIBUTING.html)
and [Code of Conduct](https://cityriverspaces.github.io/CRiSp/CODE_OF_CONDUCT.html)
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Following @SarahAlidoost's #88, I removed the cropping of `river_surface`

## Related Issues

<!--
See [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related Issue #88 
- Closes #88 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [ ] Yes
- [x] No, and this is why: I am not sure if a test is needed for this change.
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [ ] Yes
