### PR TITLE
Fix invalid buildings retrieved from OSM

### DIFF
--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -346,6 +346,8 @@ get_osm_buildings <- function(aoi, crs = NULL, force_download = FALSE) {
   buildings <- osmdata_as_sf("building", "", aoi,
                              force_download = force_download)
   buildings <- buildings$osm_polygons |>
+    # retreived buildings may contain invalid polygons, fix these
+    sf::st_make_valid() |>
     sf::st_filter(aoi, .predicate = sf::st_intersects) |>
     dplyr::filter(.data$building != "NULL") |>
     sf::st_geometry()

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -84,3 +84,16 @@ test_that("Queried datasets can be retrieved from the cache on new calls", {
   # raising a warning that includes the path to the cached file as well
   expect_warning(get_osm_railways(bb, force_download = FALSE), cached_filepath)
 })
+
+test_that("All geometries retrieved from OSM are valid", {
+  skip_on_ci()
+
+  # setup cache directory
+  temp_cache_dir()
+
+  bucharest_osm <- get_osmdata("Bucharest", "Dâmbovița", force_download = TRUE)
+
+  expect_true(all(vapply(bucharest_osm[!names(bucharest_osm) %in% "bb"],
+                         \(x) if (!inherits(x, "bbox")) all(sf::st_is_valid(x)),
+                         logical(1))))
+})


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Before submitting a Pull Request, please ensure you've read the CRiSp
[Contributing Guide](https://cityriverspaces.github.io/CRiSp/CONTRIBUTING.html)
and [Code of Conduct](https://cityriverspaces.github.io/CRiSp/CODE_OF_CONDUCT.html)
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When trying to run riverspace delineation on `"Köln", "Rhein"`, I encountered invalid building polygons. This change in PR ensures that the polygons are made valid before being intersected with the aoi.

## Related Issues

<!--
See [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [ ] Yes
