### PR TITLE
Clip river centerline before riverspace delineation

### DIFF
--- a/R/delineate.R
+++ b/R/delineate.R
@@ -117,7 +117,10 @@ delineate <- function(
   }
 
   if (riverspace) {
-    river_combined <- combine_river_features(osm_data$river_centerline,
+    river_centerline_clipped <- sf::st_intersection(
+      osm_data$river_centerline, osm_data$aoi_buildings |> sf::st_transform(crs)
+    )
+    river_combined <- combine_river_features(river_centerline_clipped,
                                              osm_data$river_surface)
     riverspace <- delineate_riverspace(osm_data$buildings,
                                        river_combined)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Before submitting a Pull Request, please ensure you've read the CRiSp
[Contributing Guide](https://cityriverspaces.github.io/CRiSp/CONTRIBUTING.html)
and [Code of Conduct](https://cityriverspaces.github.io/CRiSp/CODE_OF_CONDUCT.html)
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Before riverspace delineation, `river_centerline` is clipped to `aoi_buildings`. Riverspace delineation is almost three times faster in case of Bucharest (on my computer, reduced from 1.58 mins to 43 secs).

## Related Issues

<!--
See [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related Issue #105 
- Closes #105 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [ ] Yes
- [x] No, and this is why: I could not think of a meaningful test here. Any ideas?
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [ ] Yes
