### PR TITLE
Match updated `visor::get_isovist()` in riverspace module

### DIFF
--- a/R/delineate.R
+++ b/R/delineate.R
@@ -122,9 +122,7 @@ delineate <- function(
     )
     river_combined <- combine_river_features(river_centerline_clipped,
                                              osm_data$river_surface)
-    riverspace <- delineate_riverspace(osm_data$buildings,
-                                       river_combined)
-  } else {
+    riverspace <- delineate_riverspace(river_combined, osm_data$buildings)
     riverspace <- NULL
   }
 

--- a/R/riverspace.R
+++ b/R/riverspace.R
@@ -1,7 +1,7 @@
 #' Delineate the space surrounding a river
 #'
-#' @param occluders Geometry of occluders
 #' @param river List with river surface and centerline
+#' @param occluders Geometry of occluders
 #' @param density Density of viewpoints
 #' @param ray_num Number of rays
 #' @param ray_length Length of rays in meters
@@ -11,15 +11,15 @@
 #'
 #' @examples
 #' \dontrun{
-#'   delineate_riverspace(bucharest_osm$buildings, bucharest_osm$river_surface)
+#'   delineate_riverspace(bucharest_osm$river_surface, bucharest_osm$buildings)
 #' }
-delineate_riverspace <- function(occluders, river, density = 1 / 50,
+delineate_riverspace <- function(river, occluders = NULL, density = 1 / 50,
                                  ray_num = 41, ray_length = 100) {
   vpoints <- visor::get_viewpoints(river, density = density)
   isovists <- vector(mode = "list", length = length(vpoints))
   for (i in seq_along(vpoints)) {
     isovists[i] <-
-      visor::get_isovist(occluders, vpoints[i], ray_num, ray_length)
+      visor::get_isovist(vpoints[i], occluders, ray_num, ray_length)
   }
   riverspace <- sf::st_union(do.call(c, lapply(isovists, sf::st_sfc))) |>
     sfheaders::sf_remove_holes()

--- a/man/delineate_riverspace.Rd
+++ b/man/delineate_riverspace.Rd
@@ -5,17 +5,17 @@
 \title{Delineate the space surrounding a river}
 \usage{
 delineate_riverspace(
-  occluders,
   river,
+  occluders = NULL,
   density = 1/50,
   ray_num = 41,
   ray_length = 100
 )
 }
 \arguments{
-\item{occluders}{Geometry of occluders}
-
 \item{river}{List with river surface and centerline}
+
+\item{occluders}{Geometry of occluders}
 
 \item{density}{Density of viewpoints}
 
@@ -31,6 +31,6 @@ Delineate the space surrounding a river
 }
 \examples{
 \dontrun{
-  delineate_riverspace(bucharest_osm$buildings, bucharest_osm$river_surface)
+  delineate_riverspace(bucharest_osm$river_surface, bucharest_osm$buildings)
 }
 }

--- a/tests/testthat/test-riverspace.R
+++ b/tests/testthat/test-riverspace.R
@@ -1,5 +1,5 @@
-riverspace_actual <- delineate_riverspace(occluders = bucharest_osm$buildings,
-                                          river = bucharest_osm$river_surface,
+riverspace_actual <- delineate_riverspace(river = bucharest_osm$river_surface,
+                                          occluders = bucharest_osm$buildings,
                                           ray_length = 100)
 sf::st_crs(riverspace_actual) <- 32635
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Before submitting a Pull Request, please ensure you've read the CRiSp
[Contributing Guide](https://cityriverspaces.github.io/CRiSp/CONTRIBUTING.html)
and [Code of Conduct](https://cityriverspaces.github.io/CRiSp/CODE_OF_CONDUCT.html)
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
`delineate_riverspace` matches now the new signature of `get_isovist`

## Related Issues

<!--
See [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related Issue #123 
- Closes #123 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [ ] Yes
- [x] No, and this is why: no functionality was changed in CRiSp; tests checking input in get_isovist might be needed in visor
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [ ] Yes
