### PR TITLE
Raise error if river geometry not found

### DIFF
--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -231,6 +231,10 @@ get_osm_river <- function(bb, river_name, crs = NULL, force_download = FALSE) {
     sf::st_geometry() |>
     sf::st_union()
 
+  if (sf::st_is_empty(river_centerline)) stop(
+    sprintf("No river geometry found for %s", river_name)
+  )
+
   # Get the river surface
   river_surface <- osmdata_as_sf("natural", "water", bb,
                                  force_download = force_download)

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -128,6 +128,17 @@ test_that("River is consistently retreived with alternative names", {
   }
 })
 
+test_that("River retrieval raise error if no geometry is found", {
+  skip_on_ci()
+
+  # setup cache directory
+  temp_cache_dir()
+
+  bb <- get_osm_bb("Paris, France")
+  expect_error(get_osm_river(bb, "Thames", force_download = TRUE),
+               "Thames")
+})
+
 test_that("All geometries retrieved from OSM are valid", {
   skip_on_ci()
 


### PR DESCRIPTION
River surface can still be empty