### PR TITLE
Improved river centerline query

### DIFF
--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -220,9 +220,20 @@ get_osm_city_boundary <- function(bb, city_name, crs = NULL, multiple = FALSE,
 #' get_osm_river(bb, "Dâmbovița", crs)
 get_osm_river <- function(bb, river_name, crs = NULL, force_download = FALSE) {
   # Get the river centreline
-  river_centerline <- osmdata_as_sf("waterway", "river", bb,
-                                    force_download = force_download)
-  river_centerline <- river_centerline$osm_multilines |>
+  river_centerline_all <- osmdata_as_sf("waterway", "", bb,
+                                        force_download = force_download)
+
+  # Search for river centerlines in OSM layers
+  if (!is.null(river_centerline_all$osm_multilines)) {
+    river_centerline_all <- river_centerline_all$osm_multilines
+  } else if ((!is.null(river_centerline_all$osm_lines))) {
+    river_centerline_all <- river_centerline_all$osm_lines
+  } else stop(
+    sprintf("No river geometry found for %s", river_name)
+  )
+
+  # Retrieve river centerline of interest
+  river_centerline <- river_centerline_all |>
     # filter using any of the "name" columns (matching different languages)
     match_osm_name(river_name) |>
     check_invalid_geometry() |> # fix invalid geometries, if any

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -225,8 +225,8 @@ get_osm_river <- function(bb, river_name, crs = NULL, force_download = FALSE) {
 
   # Check that waterway geometries are found within bb
   if (is.null(river_centerline_all$osm_lines) &&
-        is.null(river_centerline_all$osm_multilines) == 0) {
-    stop(sprintf("No waterway geometries found within given boundig box"))
+        is.null(river_centerline_all$osm_multilines)) {
+    stop(sprintf("No waterway geometries found within given bounding box"))
   }
 
   river_centerline_all <- dplyr::bind_rows(

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -139,25 +139,6 @@ test_that("River retrieval raise error if no geometry is found", {
                "Thames")
 })
 
-test_that("The correct OSM line feature is chosen for river centerline", {
-  skip_on_ci()
-
-  # setup cache directory
-  temp_cache_dir()
-
-  bb <- get_osm_bb("Rio de Janeiro")
-  crs <- get_utm_zone(bb)
-  expect_message(get_osm_river(bb, "Rio Guandu",
-                               crs = crs, force_download = TRUE),
-                 "Using OSM lines for river centerline")
-
-  bb <- get_osm_bb("Bucharest")
-  crs <- get_utm_zone(bb)
-  expect_message(get_osm_river(bb, "Dâmbovița",
-                               crs = crs, force_download = TRUE),
-                 "Using OSM multilines for river centerline")
-})
-
 test_that("All geometries retrieved from OSM are valid", {
   skip_on_ci()
 
@@ -169,4 +150,24 @@ test_that("All geometries retrieved from OSM are valid", {
   expect_true(all(vapply(bucharest_osm[!names(bucharest_osm) %in% "bb"],
                          \(x) if (!inherits(x, "bbox")) all(sf::st_is_valid(x)),
                          logical(1))))
+})
+
+test_that("Both lines and multilines are retreived from river Dâmbovița", {
+  skip_on_ci()
+
+  # setup cache directory
+  temp_cache_dir()
+
+  city_names <- c("Bucharest", "Rio de Janeiro")
+  river_names <- c("Dâmbovița", "Rio Guandu")
+
+  for (i in seq_along(city_names)) {
+    city_name <- city_names[i]
+    river_name <- river_names[i]
+
+    bb <- get_osm_bb(city_name)
+    river <- get_osm_river(bb, river_name, force_download = TRUE)
+
+    expect_true(length(river) > 0)
+  }
 })

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -139,6 +139,25 @@ test_that("River retrieval raise error if no geometry is found", {
                "Thames")
 })
 
+test_that("The correct OSM line feature is chosen for river centerline", {
+  skip_on_ci()
+
+  # setup cache directory
+  temp_cache_dir()
+
+  bb <- get_osm_bb("Rio de Janeiro")
+  crs <- get_utm_zone(bb)
+  expect_message(get_osm_river(bb, "Rio Guandu",
+                               crs = crs, force_download = TRUE),
+                 "Using OSM lines for river centerline")
+
+  bb <- get_osm_bb("Bucharest")
+  crs <- get_utm_zone(bb)
+  expect_message(get_osm_river(bb, "Dâmbovița",
+                               crs = crs, force_download = TRUE),
+                 "Using OSM multilines for river centerline")
+})
+
 test_that("All geometries retrieved from OSM are valid", {
   skip_on_ci()
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Before submitting a Pull Request, please ensure you've read the CRiSp
[Contributing Guide](https://cityriverspaces.github.io/CRiSp/CONTRIBUTING.html)
and [Code of Conduct](https://cityriverspaces.github.io/CRiSp/CODE_OF_CONDUCT.html)
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
All values are retrieved from the OSM key `waterway`, not only `river`. Also, when generating the river centerline, `get_osm_river()` chooses the layer with the highest summed length between `$osm_line` and `$osm_multiline`.

## Related Issues

<!--
See [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related Issue #154 #155
- Closes #154 #155

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [ ] Yes
