### PR TITLE
Issues with fragmented rivers

### DIFF
--- a/R/corridor.R
+++ b/R/corridor.R
@@ -220,9 +220,13 @@ get_river_banks <- function(river, width) {
   river_merged <- sf::st_line_merge(river_merged)
   river_segments <- sfheaders::sfc_cast(river_merged, "LINESTRING")
 
+  # Single-sided buffers can have problems at discontinuities - build river
+  # segments that are as long as possible on the basis of continuity
+  continous_river_segments <- rcoins::stroke(river_segments)
+
   # Define the two river bank regions as single-sided buffers
-  c(river_buffer(river_segments, width, side = "right"),
-    river_buffer(river_segments, width, side = "left"))
+  c(river_buffer(continous_river_segments, width, side = "right"),
+    river_buffer(continous_river_segments, width, side = "left"))
 }
 
 #' Identify the initial edges of the river corridor


### PR DESCRIPTION
Problems might arise with rivers whose centerline is composed by multiple segments (e.g. due to the presence of islands).
See e.g. the case of Paris, for which I have encountered the issue when trying to lower the value `network_buffer` in order to improve the corridor delineation with meanders.   

The following script would return the problematic corridor:
```r
devtools::load_all()

city_name <- "Paris"
river_name <- "La Seine"
network_buffer <- 1500
dem_buffer <- 2500
force_download <- FALSE

# Download OSM datasets
bb <- CRiSp::get_osm_bb(city_name)
crs <- CRiSp::get_utm_zone(bb)
osm_data <- CRiSp::get_osmdata(
  city_name, river_name, network_buffer = network_buffer,
  buildings_buffer = NULL, city_boundary = FALSE, crs = crs,
  force_download = force_download
)

# Download DEM
aoi <- CRiSp::reproject(osm_data$aoi_network, crs)
aoi_dem <- buffer(osm_data$aoi_network, dem_buffer) # from utils.R
dem <- CRiSp::get_dem(aoi_dem, crs = crs, force_download = force_download)

network <- dplyr::bind_rows(osm_data$streets, osm_data$railways) |>
  CRiSp::as_network()
corridor <- CRiSp::delineate_corridor(
  network,
  osm_data$river_centerline,
  max_width = network_buffer,
  aoi = sf::st_transform(aoi, crs),
  dem = dem,
  capping_method = "shortest-path"
)
```

A big part of the river gets excluded from the delineation, see here:

<img width="656" alt="Screenshot 2025-04-25 at 15 53 14" src="https://github.com/user-attachments/assets/e60f2474-8f01-4a66-9c0f-20acd88e88ca" />

The issue originates from the fact that single-sided buffers, which we use in order to select the spatial network on the two river banks, have problems in correspondence of discontinuities.

This PR uses rcoins to get more continuous segments in the river centerline. This seems to solve the issue, since the script above returns a delineation of the full corridor:

<img width="656" alt="Screenshot 2025-04-25 at 15 51 13" src="https://github.com/user-attachments/assets/1e4e1c14-692b-46af-a341-eaddd195a8a0" />


 