### PR TITLE
Increase default value of network buffer

### DIFF
--- a/R/corridor.R
+++ b/R/corridor.R
@@ -39,7 +39,7 @@
 #'                      dem = terra::unwrap(CRiSpData::bucharest_dem))
 #' }
 delineate_corridor <- function(
-  network, river_centerline, aoi = NULL, max_width = 2500,
+  network, river_centerline, aoi = NULL, max_width = 3000,
   initial_method = "valley", buffer = NULL, dem = NULL, max_iterations = 10,
   capping_method = "shortest-path"
 ) {

--- a/R/delineate.R
+++ b/R/delineate.R
@@ -6,7 +6,7 @@
 #'   provided, the suitable Universal Transverse Mercator (UTM) CRS is selected
 #' @param network_buffer Add a buffer (an integer in meters) around
 #'   river to retrieve additional data (streets, railways, etc.).
-#'   Default is 2500 m.
+#'   Default is 3000 m.
 #' @param buildings_buffer Add a buffer (an integer in meters) around the
 #'   river to retrieve additional data (buildings). Default is 100 m.
 #' @param dem_buffer Add a buffer (an integer in meters) for retrieving the DEM.
@@ -51,7 +51,7 @@ delineate <- function(
 
   # set default values for network_buffer and buildings_buffer
   if (corridor && is.null(network_buffer)) {
-    network_buffer <- 2500
+    network_buffer <- 3000
     message(sprintf(
       "The default `network_buffer` of %d m is used for corridor delineation.",
       network_buffer

--- a/R/delineate.R
+++ b/R/delineate.R
@@ -13,7 +13,7 @@
 #' @param initial_method The method employed to define the initial river
 #'   corridor geometry. See [initial_corridor()] for the available methods
 #' @param dem_buffer Add a buffer (an integer in meters) around the
-#'   river to retrieve the DEM. Default is 2500 m.
+#'   river to retrieve the DEM.
 #' @param initial_buffer Buffer region to add to the river geometry to setup the
 #'   initial corridor (only used if `initial_method` is `"buffer"`)
 #' @param dem Digital elevation model (DEM) of the region (only used if

--- a/man/delineate.Rd
+++ b/man/delineate.Rd
@@ -34,7 +34,7 @@ provided, the suitable Universal Transverse Mercator (UTM) CRS is selected}
 
 \item{network_buffer}{Add a buffer (an integer in meters) around
 river to retrieve additional data (streets, railways, etc.).
-Default is 2500 m.}
+Default is 3000 m.}
 
 \item{buildings_buffer}{Add a buffer (an integer in meters) around the
 river to retrieve additional data (buildings). Default is 100 m.}

--- a/man/delineate.Rd
+++ b/man/delineate.Rd
@@ -40,7 +40,7 @@ Default is 3000 m.}
 river to retrieve additional data (buildings). Default is 100 m.}
 
 \item{dem_buffer}{Add a buffer (an integer in meters) around the
-river to retrieve the DEM. Default is 2500 m.}
+river to retrieve the DEM.}
 
 \item{initial_method}{The method employed to define the initial river
 corridor geometry. See \code{\link[=initial_corridor]{initial_corridor()}} for the available methods}

--- a/man/delineate_corridor.Rd
+++ b/man/delineate_corridor.Rd
@@ -8,7 +8,7 @@ delineate_corridor(
   network,
   river_centerline,
   aoi = NULL,
-  max_width = 2500,
+  max_width = 3000,
   initial_method = "valley",
   buffer = NULL,
   dem = NULL,


### PR DESCRIPTION
For some cases (e.g. Warsaw and Rome), the default value of network buffer is too small - we increase this from 2500m to 3000m 