### PR TITLE
Return empty sf object if no railways are found

### DIFF
--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -336,6 +336,13 @@ get_osm_streets <- function(aoi, crs = NULL, highway_values = NULL,
 get_osm_railways <- function(aoi, crs = NULL, force_download = FALSE) {
   railways <- osmdata_as_sf("railway", "rail", aoi,
                             force_download = force_download)
+  # If no railways are found, return an empty sf object
+  if (is.null(railways$osm_lines)) {
+    if (is.null(crs)) crs <- sf::st_crs("EPSG:4326")
+    empty_sf <- sf::st_sf(geometry = sf::st_sfc(crs = crs))
+    return(empty_sf)
+  }
+
   railways_lines <- railways$osm_lines |>
     dplyr::select("railway") |>
     dplyr::rename(!!sym("type") := !!sym("railway"))

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -172,3 +172,14 @@ test_that("Both lines and multilines are retreived from river Dâmbovița", {
     expect_true(length(river) > 0)
   }
 })
+
+test_that("If no railways are found, an empty sf object is returned", {
+  crs <- sf::st_crs("EPSG:32632")
+  aoi <- sf::st_bbox(c(xlim = 1, xmax = 2, ylim = 1, ymax = 2))
+  mocked_osmdata_response <- list(osm_lines = NULL)
+  with_mocked_bindings(osmdata_as_sf = function(...) mocked_osmdata_response, {
+    railways <- get_osm_railways(aoi, crs = crs, force_download = FALSE)
+  })
+  expect_equal(nrow(railways), 0)
+  expect_equal(sf::st_crs(railways), crs)
+})


### PR DESCRIPTION
The following error is raised if we try to delineate a region without railways:
```
Error in UseMethod("select") : 
  no applicable method for 'select' applied to an object of class "NULL"
Calls: retrieve_data ... get_network -> get_osm_railways -> <Anonymous> -> <Anonymous>
```

This fix allows `get_osm_railways` to return an empty `sf` object if no railways are found, so that the workflow can continue with the spatial network being based on streets only.