### PR TITLE
Improvements for search for city boundaries

### DIFF
--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -173,7 +173,7 @@ get_osm_city_boundary <- function(bb, city_name, crs = NULL, multiple = FALSE,
   # Define a helper function to fetch the city boundary
   fetch_boundary <- function(key, value) {
     osmdata_sf <- osmdata_as_sf(key, value, bb, force_download = force_download)
-    osmdata_sf$osm_multipolygons |>
+    dplyr::bind_rows(osmdata_sf$osm_polygons, osmdata_sf$osm_multipolygons) |>
       # filter using any of the "name" columns (matching different languages)
       match_osm_name(city_name_clean) |>
       sf::st_geometry()

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -416,6 +416,9 @@ get_river_aoi <- function(river, city_bbox, buffer_distance) {
 #' @return sf object containing only rows with filtered name
 #' @keywords internal
 match_osm_name <- function(osm_data, match) {
-  dplyr::filter(osm_data, dplyr::if_any(dplyr::matches("name"),
-                                        \(x) x == match))
+  # Function to find partial matches across rows of a data frame
+  includes_match <- \(x) grepl(match, x, ignore.case = TRUE)
+  # Apply function above to all columns whose name starts with "name", thus
+  # checking for matches in all listed languages
+  dplyr::filter(osm_data, dplyr::if_any(dplyr::matches("name"), includes_match))
 }

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -183,9 +183,7 @@ get_osm_city_boundary <- function(bb, city_name, crs = NULL, multiple = FALSE,
   city_boundary <- tryCatch(fetch_boundary("boundary", "administrative"),
                             error = function(e) NULL)
 
-  if (!is.null(city_boundary)) {
-    message("City boundary found with 'boundary:administrative' tag.")
-  } else {
+  if (is.null(city_boundary)) {
     stop("No city boundary found. The city name may be incorrect.")
   }
 

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -183,3 +183,18 @@ test_that("If no railways are found, an empty sf object is returned", {
   expect_equal(nrow(railways), 0)
   expect_equal(sf::st_crs(railways), crs)
 })
+
+test_that("Partial matches of names are accounted for", {
+  data <- data.frame(
+    name = c("match", "xxx", "xxx", "xxx"),
+    `name:xx` = c("xxx", "This is also a match", "xxx", "xxx"),
+    `name:yy` = c("xxx", "xxx", "THIS IS ALSO A MATCH", "xxx"),
+    discarded = c("xxx", "xxx", "xxx", "This is not a match")
+  )
+  res <- match_osm_name(data, "match")
+  # Partial matches allowed, not case-sensitive. However, "name"
+  # should be in the column name
+  expect_equal(nrow(res), 3)
+  # All columns are returned
+  expect_equal(ncol(res), 4)
+})


### PR DESCRIPTION
* Adding partial matches for names and river - useful to retrieve some input data for the CRiSp dataset. Closes #67 , hope this is good enough even if we don't handle misspellings? 
* Search for city boundary in both OSM polygons and multipolygons (some cities, e.g. "Belfast", would be missed if only multipolygons are considered).
* A message that was printed out every time city boundaries are found is removed to reduce verbosity
