### PR TITLE
Increase timeout for example data retrieval

### DIFF
--- a/R/exampledata.R
+++ b/R/exampledata.R
@@ -16,7 +16,10 @@ get_osm_example_data <- function() {
   url_osm <- "https://data.4tu.nl/file/f5d5e118-b5bd-4dfb-987f-fe10d1b9b386/f519315e-b92d-4815-b924-3175bd2a7a61"
   # nolint end
   temp_file <- tempfile(fileext = ".gpkg")
-  download.file(url_osm, destfile = temp_file, mode = "wb")
+  # temporarily increate timeout, reset value on exit
+  op <- options(timeout = 300)
+  on.exit(op)
+  download.file(url_osm, destfile = temp_file, mode = "wb", quiet = TRUE)
   names <- sf::st_layers(temp_file)$name
   lapply(names, \(layer) sf::st_read(temp_file, layer = layer, quiet = TRUE)) |>
     setNames(names)


### PR DESCRIPTION
Some of the checks are failing due to the `download.file` function timing out during vignette preparation or tests, this PR tries to solve the issue.