### PR TITLE
Fix outdated city boundary test

### DIFF
--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -12,10 +12,8 @@ test_that("City boundary of Bucharest is correctly retreived", {
   city_name <- "Bucharest"
   bb <- get_osm_bb(city_name)
 
-  expect_message(bucharest_boundary <-
-                   get_osm_city_boundary(bb, city_name,
-                                         force_download = TRUE),
-                 "City boundary found with 'boundary:administrative' tag.")
+  bucharest_boundary <- get_osm_city_boundary(bb, city_name,
+                                              force_download = TRUE)
   expect_equal(as.numeric(bb), as.numeric(sf::st_bbox(bucharest_boundary)))
 })
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix (not really a bug, but I did not know how else to categorise it)
- [ ] Optimization
- [ ] Documentation Update

## Description
This fixes a test that was only failing locally (skipped on CI) after the `get_osm_city_boundary()` function was modified in #195.

## Related Issues

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes, updated test
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?

- [ ] Yes
