### PR TITLE
Remove message suppression with sf warning

### DIFF
--- a/R/network.R
+++ b/R/network.R
@@ -81,7 +81,7 @@ flatten_network <- function(network) {
 #' @noRd
 get_crossing_edges <- function(edges) {
   geometry <- sf::st_geometry(edges)
-  crossings <- sf::st_crosses(geometry) |> suppressMessages()
+  crossings <- sf::st_crosses(geometry)
   mask <- lengths(crossings) > 0
   sf::st_sf(id = which(mask), geometry = geometry[mask])
 }
@@ -91,7 +91,7 @@ get_crossing_edges <- function(edges) {
 #' @noRd
 get_intersection_points <- function(edges) {
   # make sure edges is an sf object, so st_intersection also returns origins
-  intersections <- sf::st_intersection(sf::st_sf(edges)) |> suppressMessages()
+  intersections <- sf::st_intersection(sf::st_sf(edges))
   # only consider (multi-)point intersections
   points <- sf::st_collection_extract(intersections, type = "POINT")
   # cast multipoint intersections to points


### PR DESCRIPTION
These messages ([this](https://github.com/CityRiverSpaces/rcrisp/pull/265/files#r2207486200) and [this](https://github.com/CityRiverSpaces/rcrisp/pull/265/files#r2207487075))are indeed the informative messages from SF on the less suitability to use geographic CRS here, so we might remove them. The autotest issue will probably get solved since non-geographic CRSs will be stopped earlier.  