### PR TITLE
Skip test when stac asset urls retrieval fails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug for river with no crossings was fixed. Delineation fails with informative error.
 - Code chunk with OSM data retrieval was disabled in getting started vignette.
 - `get_osm_buildings()` does not error when given bounding box as input.
+- STAC asset URL retrieval test fails gracefully on unsuccessful HTTP request.
 
 ## Changed
 

--- a/tests/testthat/test-valley.R
+++ b/tests/testthat/test-valley.R
@@ -13,6 +13,7 @@ asset_urls <- c(paste0("s3://copernicus-dem-30m/",
 
 test_that("STAC asset urls are correctly retrieved", {
   skip_on_ci()
+  skip_on_cran()
 
   ep <- "https://earth-search.aws.element84.com/v1"
   col <- "cop-dem-glo-30"

--- a/tests/testthat/test-valley.R
+++ b/tests/testthat/test-valley.R
@@ -17,8 +17,19 @@ test_that("STAC asset urls are correctly retrieved", {
   ep <- "https://earth-search.aws.element84.com/v1"
   col <- "cop-dem-glo-30"
 
-  asset_urls_retrieved <- get_stac_asset_urls(bb, endpoint = ep,
-                                              collection = col)
+  asset_urls_retrieved <- tryCatch(
+    {
+      get_stac_asset_urls(bb, endpoint = ep, collection = col)
+    },
+    error = function(e) {
+      if (grepl("HTTP", conditionMessage(e), ignore.case = TRUE)) {
+        skip(paste("Skipped due to HTTP error:", conditionMessage(e)))
+      } else {
+        stop(e)
+      }
+    }
+  )
+
   expected_asset_urls <- asset_urls
 
   expect_equal(expected_asset_urls, asset_urls_retrieved)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Before submitting a Pull Request, please ensure you've read the rcrisp
[Contributing Guide](https://cityriverspaces.github.io/rcrisp/CONTRIBUTING.html)
and [Code of Conduct](https://cityriverspaces.github.io/rcrisp/CODE_OF_CONDUCT.html)
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Issues
- Related Issue #342 
- Closes #342

## Added/updated tests?

- [x] Yes, an existing test was fixed
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [x] Yes
