### PR TITLE
Fix "wrong city name" test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug for river with no crossings was fixed. Delineation fails with informative error.
 - Code chunk with OSM data retrieval was disabled in getting started vignette.
 - `get_osm_buildings()` does not error when given bounding box as input.
+- Suppress warning in wrong city name test.
 
 ## Changed
 

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -247,8 +247,8 @@ get_osm_city_boundary <- function(bb, city_name, crs = NULL, multiple = FALSE,
       # filter using any of the "name" columns (matching different languages)
       match_osm_name(city_name_clean) |>
       dplyr::filter(
-        suppressWarnings(as.numeric(.data$admin_level)) ==
-          max(suppressWarnings(as.numeric(.data$admin_level)), na.rm = TRUE)
+        suppressWarnings(as.numeric(.data$admin_level) ==
+          max(as.numeric(.data$admin_level), na.rm = TRUE))
       ) |>
       sf::st_geometry()
   }

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -248,7 +248,7 @@ get_osm_city_boundary <- function(bb, city_name, crs = NULL, multiple = FALSE,
       match_osm_name(city_name_clean) |>
       dplyr::filter(
         suppressWarnings(as.numeric(.data$admin_level) ==
-          max(as.numeric(.data$admin_level), na.rm = TRUE))
+                           max(as.numeric(.data$admin_level), na.rm = TRUE))
       ) |>
       sf::st_geometry()
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
#344 happens only when wrong city name si provided, so I think suppressing the warning should be okay.

## Related Issues

- Related Issue #344 
- Closes #344

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [x] Yes, updated test
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [x] Yes
