### PR TITLE
Fix geometry validatin in OSM building retrieval

### DIFF
--- a/R/network.R
+++ b/R/network.R
@@ -188,7 +188,7 @@ insert_intersections <- function(edges, points, tol = 1.e-3) {
     x = "x", y = "y", linestring_id = "linestring_id"
   )
   sf::st_crs(edges_new) <- sf::st_crs(edges)
-  return(edges_new)
+  edges_new
 }
 
 #' Check if a point is within a given edge.

--- a/R/segments.R
+++ b/R/segments.R
@@ -217,7 +217,7 @@ select_nonintersecting_lines <- function(lines, corridor) {
   } else {
     # Identify the line with maximum number of intersections
     intersecting_lines <- intersections[["origins"]]
-    num_intersections <- vapply(seq_len(length(lines)),
+    num_intersections <- vapply(seq_along(lines),
                                 \(x) sum(unlist(intersecting_lines) == x),
                                 integer(1))
     max_intersections <- max(num_intersections)

--- a/R/utils.R
+++ b/R/utils.R
@@ -203,7 +203,7 @@ river_buffer <- function(river, buffer_distance, bbox = NULL, side = NULL) {
   if (!is.null(bbox)) river <- sf::st_crop(river, bbox)
   if (is.null(side)) {
     river_buf <- buffer(river, buffer_distance)
-    return(sf::st_union(river_buf))
+    sf::st_union(river_buf)
   } else {
     if (side == "left") {
       river_buf <- buffer(river, buffer_distance, singleSide = TRUE)
@@ -218,7 +218,7 @@ river_buffer <- function(river, buffer_distance, bbox = NULL, side = NULL) {
     splits <- split_by(sf::st_union(river_buf), river)
     river_buf <- splits[find_largest(splits)]
     # Finally drop any eventual hole
-    return(sfheaders::sf_remove_holes(river_buf))
+    sfheaders::sf_remove_holes(river_buf)
   }
 }
 

--- a/R/valley.R
+++ b/R/valley.R
@@ -270,7 +270,7 @@ mask_slope <- function(slope, river, lthresh = 1.e-3, target = 0) {
   slope_masked <- terra::mask(slope,
                               terra::ifel(slope <= lthresh, NA, 1),
                               updatevalue = lthresh)
-  for (ngeom in seq_len(length(sf::st_geometry(river)))) {
+  for (ngeom in seq_along(sf::st_geometry(river))) {
     slope_masked <- terra::mask(slope_masked,
                                 terra::vect(river[ngeom]),
                                 inverse = TRUE,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
While fixing the OSM vignette in #374 and #375, I encountered an issue with building retrieval. `$osm_polygon` had invalid geometry which would not be fixed with `sf::st_make_valid()`. Instead I use `lwgeom::lwgeom_make_valid()`.

Also, building retrieval should only be possible with AOI, right? bbox was still an opption so I removed that one.

## Related Issues

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [x] Yes
