### PR TITLE
add documentation reminding other possible water bodies may be included

### DIFF
--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -345,6 +345,14 @@ get_osm_river_centerline <- function(bb, river_name, crs = NULL,
 
 #' Get the river surface from OpenStreetMap
 #'
+#' River surface is derived from OSM polygons tagged `natural=water` that
+#' intersect the provided river centerline, and then unioned.
+#' This assumes intersecting water polygons represent the target river
+#' corridor. Depending on local OSM mapping, intersecting features may include
+#' `water=reservoir`, `water=lake`, or other complex water bodies. For analyses
+#' targeting only the main river surface, results should be inspected and
+#' non-river water bodies removed where needed.
+#'
 #' @param bb Bounding box of class `bbox`
 #' @param river_centerline The river centerline as an object of class
 #'   [`sf::sfc_LINESTRING`] or [`sf::sfc_MULTILINESTRING`]


### PR DESCRIPTION
#368  add documentation reminding other possible water bodies may be included when getting osm river polygons
