### PR TITLE
Restore srr chunks in precompiled vignettes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+
+## Fixed
+
+- Vignette pre-compilation was updated so that srr tags dropped by `knitr::knit()` are reinserted into the vignettes. Affected vignettes were also recompiled.
+
 # rcrisp 0.3.1 - 2025-11-24
 
 ## Changed

--- a/vignettes/precompile.R
+++ b/vignettes/precompile.R
@@ -7,11 +7,61 @@
 # re-generate them!
 vigs_orig <- list.files(".", pattern = "\\.Rmd.orig")
 
+# Extract all srr chunks from an .Rmd file as a character vector of lines.
+# Chunks with eval=FALSE, echo=FALSE are silently dropped by knitr::knit(), so
+# we retrieve them from the .Rmd.orig files and reinsert them after knitting.
+extract_srr_chunks <- function(lines) {
+  result <- character(0)
+  in_srr_chunk <- FALSE
+  chunk_lines <- character(0)
+
+  for (line in lines) {
+    if (grepl("^```\\{r srr", line)) {
+      in_srr_chunk <- TRUE
+      chunk_lines <- line
+    } else if (in_srr_chunk) {
+      chunk_lines <- c(chunk_lines, line)
+      if (grepl("^```\\s*$", line)) {
+        result <- c(result, chunk_lines, "")
+        in_srr_chunk <- FALSE
+        chunk_lines <- character(0)
+      }
+    }
+  }
+  result
+}
+
 for (vig_orig in vigs_orig) {
   vig <- gsub(".orig", "", vig_orig)
   # Only knit the vignettes that are missing
   if (!file.exists(vig)) {
     knitr::knit(vig_orig, vig)
+
+    # Reinsert srr chunks that are lost during knitting
+    orig_lines <- readLines(vig_orig)
+    srr_chunks <- extract_srr_chunks(orig_lines)
+
+    if (length(srr_chunks) > 0) {
+      vig_lines <- readLines(vig)
+
+      # Insert right after the "generated from .orig" comment line
+      comment_pos <- grep("generated from the \\*\\.Rmd\\.orig", vig_lines)
+      if (length(comment_pos) > 0) {
+        insert_pos <- comment_pos[1]
+      } else {
+        # Fall back: after the closing --- of the YAML front matter
+        yaml_markers <- which(vig_lines == "---")
+        insert_pos <- if (length(yaml_markers) >= 2) yaml_markers[2] else 1L
+      }
+
+      vig_lines <- c(
+        vig_lines[seq_len(insert_pos)],
+        "",
+        srr_chunks,
+        vig_lines[(insert_pos + 1L):length(vig_lines)]
+      )
+      writeLines(vig_lines, vig)
+    }
   } else {
     message(paste("Vignette", vig, "already exists! Skipping it ..."))
   }

--- a/vignettes/vig_01-method.Rmd
+++ b/vignettes/vig_01-method.Rmd
@@ -9,6 +9,14 @@ vignette: >
 
 <!-- the *.Rmd vignettes are generated from the *.Rmd.orig files. Please edit those files. -->
 
+```{r srr-tags, eval=FALSE, echo=FALSE}
+#' @srrstats {G1.0} This vignette provides a publication describing an early
+#'   version of the method implemented in the package.
+#' @srrstats {G1.1} It is specified here that `rcrisp` is the first
+#'   implementation of a novel algorithm.
+```
+
+
 
 
 

--- a/vignettes/vig_03-network-preparation.Rmd
+++ b/vignettes/vig_03-network-preparation.Rmd
@@ -9,6 +9,12 @@ vignette: >
 
 <!-- the *.Rmd vignettes are generated from the *.Rmd.orig files. Please edit those files. -->
 
+```{r srr-tags, eval=FALSE, echo=FALSE}
+#' @srrstats {SP2.2a} This vignette demonstrates the compatibility of `rcrisp`
+#'   routines with `sfnetworks` workflows.
+```
+
+
 
 
 

--- a/vignettes/vig_04-valley-delineation.Rmd
+++ b/vignettes/vig_04-valley-delineation.Rmd
@@ -11,6 +11,22 @@ csl: apa.csl
 
 <!-- the *.Rmd vignettes are generated from the *.Rmd.orig files. Please edit those files. -->
 
+```{r srr-tags, eval=FALSE, echo=FALSE}
+#' @srrstats {G1.0} This vignette provides several literature references used
+#'   for the method of valley delineation.
+#' @srrstats {G1.3} Literature references are given for the Cost Distance
+#'   algorithm used for valley delineation.
+#' @srrstats {G2.10} This vignette uses `sf::st_geometry()` to extract the
+#'   geometry column from the `bucharest_osm$river_centerline` and
+#'   `bucharest_osm$river_surface`. This is used when only geometry information
+#'   is needed from that point onwards and all other attributes (i.e., columns)
+#'   can be safely discarded. The object returned by `sf::st_geometry()` is a
+#'   simple feature geometry list column of class `sfc`.
+#' @srrstats {SP2.2a} This vignette demonstrates the compatibility of `rcrisp`
+#'   routines with `terra` workflows.
+```
+
+
 
 
 

--- a/vignettes/vig_06-corridor-segmentation.Rmd
+++ b/vignettes/vig_06-corridor-segmentation.Rmd
@@ -9,6 +9,18 @@ vignette: >
 
 <!-- the *.Rmd vignettes are generated from the *.Rmd.orig files. Please edit those files. -->
 
+```{r srr-tags, eval=FALSE, echo=FALSE}
+#' @srrstats {G2.10} This vignette uses `sf::st_geometry()` to extract the
+#'   geometry column from the `sf` objects `bucharest_osm$river_centerline` and
+#'   `streets`. This is used when only geometry information is needed from that
+#'   point onwards and all other attributes (i.e., columns) can be safely
+#'   discarded. The object returned by `sf::st_geometry()` is a simple feature
+#'   geometry list column of class `sfc`.
+#' @srrstats {SP2.2a} This vignette demonstrates the compatibility of `rcrisp`
+#'   routines with `sf` workflows.
+```
+
+
 
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
As we observed previously in https://github.com/CityRiverSpaces/rcrisp/pull/349 and as pointed out now in https://github.com/ropensci/software-review/issues/718#issuecomment-4488190932, srr chunks were dropped in the precompiled vignettes. As a result, the srr check fails because some srr tags are found only in vignettes. I have updated the precompile script to reinsert the srr chunks dropped by `knittr::knit()` and recompiled the affected vignettes.

## Related Issues

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [ ] Yes
- [x] No, and this is why: this is a documentation update which does not require changes in tests.
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [x] Yes
