### PR TITLE
Warn and document OSM river surface assumptions

### DIFF
--- a/R/riverspace.R
+++ b/R/riverspace.R
@@ -6,6 +6,12 @@
 #' @param ray_num Number of rays as numeric vector of length one
 #' @param ray_length Length of rays in meters as numeric vector of length one
 #'
+#' @details For riverspace delineation, OSM water polygons intersecting the
+#'   river centerline are treated as part of the river, including connected
+#'   water bodies such as lakes and reservoirs. Viewpoints are calculated from
+#'   water edges where available, and from the river centerline when river
+#'   surface polygons are missing or partial.
+#'
 #' @return Riverspace as object of class [`sf::sfc_POLYGON`]
 #' @export
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -319,9 +319,11 @@ combine_river_features <- function(river_centerline, river_surface) {
   if (n_uncovered > 0) {
     warning(sprintf(
       paste(
-        "For the river centerline segment(s) with length >= 100 m, %d segment(s) are not covered by OSM river surface polygons.",
-        "This may be due to underground river sections or incomplete OSM river surface data.",
-        "Viewpoints for these segments will therefore be calculated from the river centerline."
+        "For the river centerline segment(s) with length >= 100 m,",
+        "%d segment(s) are not covered by OSM river surface polygons.",
+        "This may be due to underground river sections or incomplete OSM",
+        "river surface data. Viewpoints for these segments will therefore",
+        "be calculated from the river centerline."
       ),
       n_uncovered
     ), call. = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -309,6 +309,23 @@ combine_river_features <- function(river_centerline, river_surface) {
   message("Calculating viewpoints from both river edge and river centerline.")
   river_centerline_clipped <- sf::st_geometry(river_centerline) |>
     sf::st_difference(river_surface)
+  # Use 100 m as an empirical threshold to filter out minor geometry issues.
+  n_uncovered <- sum(
+    as.numeric(sf::st_length(
+      sf::st_cast(river_centerline_clipped, "LINESTRING", warn = FALSE)
+    )) >= 100,
+    na.rm = TRUE
+  )
+  if (n_uncovered > 0) {
+    warning(sprintf(
+      paste(
+        "For the river centerline segment(s) with length >= 100 m, %d segment(s) are not covered by OSM river surface polygons.",
+        "This may be due to underground river sections or incomplete OSM river surface data.",
+        "Viewpoints for these segments will therefore be calculated from the river centerline."
+      ),
+      n_uncovered
+    ), call. = FALSE)
+  }
   c(river_centerline_clipped, sf::st_geometry(river_surface)) |>
     sf::st_cast("MULTILINESTRING") |>
     sf::st_union()

--- a/vignettes/vig_05-corridor-delineation.Rmd.orig
+++ b/vignettes/vig_05-corridor-delineation.Rmd.orig
@@ -44,6 +44,8 @@ We start by demonstrating the use of the all-in-one `delineate()` function which
 
 4. Delineates the corridor based on the pre-processed network and initial corridor. Optionally, the corridor is split into segments based on the network and the river space is delineated.
 
+For corridor delineation, street and rail networks are assumed to be outside the river valley area. Water bodies intersecting the river centerline are treated as part of the river input.
+
 The `delineate()` function carries out the above steps in one and returns a list that by default contains the following output elements: `corridor`, `segments`, and `riverspace`.
 
 ```{r delineate}

--- a/vignettes/vig_05-corridor-delineation.Rmd.orig
+++ b/vignettes/vig_05-corridor-delineation.Rmd.orig
@@ -44,8 +44,6 @@ We start by demonstrating the use of the all-in-one `delineate()` function which
 
 4. Delineates the corridor based on the pre-processed network and initial corridor. Optionally, the corridor is split into segments based on the network and the river space is delineated.
 
-For corridor delineation, street and rail networks are assumed to be outside the river valley area. Water bodies intersecting the river centerline are treated as part of the river input.
-
 The `delineate()` function carries out the above steps in one and returns a list that by default contains the following output elements: `corridor`, `segments`, and `riverspace`.
 
 ```{r delineate}

--- a/vignettes/vig_07-riverspace-delineation.Rmd
+++ b/vignettes/vig_07-riverspace-delineation.Rmd
@@ -28,7 +28,7 @@ buildings <- bucharest_osm$buildings
 river <- bucharest_osm$river_surface
 ```
 
-The `delineate_riverspace()` function takes the building polygons and the river surface polygons as input. If no river is provided, it will return an error message. If no buildings are provided, it will return an unobstructed buffer of a given radius with a warning message. The function returns an sf polygon.
+The `delineate_riverspace()` function takes the building polygons and the river (including surface polygons and centerline) as input. The river surface polygons intersecting the river centerline are treated as part of the river, including connected water bodies such as lakes and reservoirs. Viewpoints are calculated from water edges where available, and from the river centerline when river surface polygons are missing or partial. If no river is provided, it will return an error message. If no buildings are provided, it will return an unobstructed buffer of a given radius with a warning message. The function returns an sf polygon.
 
 
 ``` r

--- a/vignettes/vig_07-riverspace-delineation.Rmd.orig
+++ b/vignettes/vig_07-riverspace-delineation.Rmd.orig
@@ -34,9 +34,7 @@ buildings <- bucharest_osm$buildings
 river <- bucharest_osm$river_surface
 ```
 
-The `delineate_riverspace()` function takes the building polygons and the river surface polygons as input. If no river is provided, it will return an error message. If no buildings are provided, it will return an unobstructed buffer of a given radius with a warning message. The function returns an sf polygon.
-
-OSM water polygons intersecting the river centerline are treated as part of the river, including connected water bodies such as lakes and reservoirs. Viewpoints are calculated from water edges where available, and from the river centerline when river surface polygons are missing or partial.
+The `delineate_riverspace()` function takes the building polygons and the river (including surface polygons and centerline) as input. The river surface polygons intersecting the river centerline are treated as part of the river, including connected water bodies such as lakes and reservoirs. Viewpoints are calculated from water edges where available, and from the river centerline when river surface polygons are missing or partial. If no river is provided, it will return an error message. If no buildings are provided, it will return an unobstructed buffer of a given radius with a warning message. The function returns an sf polygon.
 
 ```{r riverspace}
 riverspace <- delineate_riverspace(river, buildings)

--- a/vignettes/vig_07-riverspace-delineation.Rmd.orig
+++ b/vignettes/vig_07-riverspace-delineation.Rmd.orig
@@ -36,7 +36,7 @@ river <- bucharest_osm$river_surface
 
 The `delineate_riverspace()` function takes the building polygons and the river surface polygons as input. If no river is provided, it will return an error message. If no buildings are provided, it will return an unobstructed buffer of a given radius with a warning message. The function returns an sf polygon.
 
-For riverspace delineation, OSM water polygons intersecting the river centerline are treated as part of the river, including connected water bodies such as lakes and reservoirs. Viewpoints are calculated from water edges where available, and from the river centerline when river surface polygons are missing or partial.
+OSM water polygons intersecting the river centerline are treated as part of the river, including connected water bodies such as lakes and reservoirs. Viewpoints are calculated from water edges where available, and from the river centerline when river surface polygons are missing or partial.
 
 ```{r riverspace}
 riverspace <- delineate_riverspace(river, buildings)

--- a/vignettes/vig_07-riverspace-delineation.Rmd.orig
+++ b/vignettes/vig_07-riverspace-delineation.Rmd.orig
@@ -36,6 +36,8 @@ river <- bucharest_osm$river_surface
 
 The `delineate_riverspace()` function takes the building polygons and the river surface polygons as input. If no river is provided, it will return an error message. If no buildings are provided, it will return an unobstructed buffer of a given radius with a warning message. The function returns an sf polygon.
 
+For riverspace delineation, OSM water polygons intersecting the river centerline are treated as part of the river, including connected water bodies such as lakes and reservoirs. Viewpoints are calculated from water edges where available, and from the river centerline when river surface polygons are missing or partial.
+
 ```{r riverspace}
 riverspace <- delineate_riverspace(river, buildings)
 ```


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Before submitting a Pull Request, please ensure you've read the rcrisp
[Contributing Guide](https://cityriverspaces.github.io/rcrisp/CONTRIBUTING.html)
and [Code of Conduct](https://cityriverspaces.github.io/rcrisp/CODE_OF_CONDUCT.html)
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [x] Documentation Update

## Description

- Add a warning in combine_river_features() when clipped river centerline segments (>=100) are not covered by OSM river surface polygons. 100 was chosen based on empirical tests.
- Clarify that OSM water polygons crossing the river centerline are treated as part of the river space, including connected lakes and reservoirs.
- Note that viewpoints may fall back to the river centerline when river surface polygons are missing or incomplete.
- Clarify the corridor delineation assumption


## Related Issues
<!--
See [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related Issue #368 
- Closes #368 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [ ] Yes
