### PR TITLE
Add the check for number of crossings in delineate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Context-specific messages are now issued in `get_river_aoi()`, `delineate_corridor()`, and `delineate()` when lat/lon input is reprojected for buffering, and in `delineate()` when no CRS is provided and a UTM zone is auto-selected.
 - Tests were added to `delineate_corridor()`, `delineate_segments()`, and `delineate_riverspace()` to verify that geographic (lat/lon) CRS input raises an informative error.
 - The Rbanism community badge was added in the README.
+- `delineate()` now errors early when fewer than two river crossings are found.
 
 ## Fixed
 

--- a/R/delineate.R
+++ b/R/delineate.R
@@ -144,7 +144,10 @@ delineate <- function(
     # Too few river crossings may lead to failed corridor delineation.
     if (length(crossings_clustered) < 2) {
       stop(sprintf(
-        "Insufficient OSM data: %d river crossings found, but at least 2 are required.",
+        paste(
+          "Insufficient OSM data: %d river crossings found,",
+          "but at least 2 are required."
+        ),
         length(crossings_clustered)
       ))
     }

--- a/R/delineate.R
+++ b/R/delineate.R
@@ -23,6 +23,10 @@ NULL
 #' delineation, corridor segmentation and/or riverspace delineation as indicated
 #' by the user.
 #'
+#' Corridor delineation depends on the availability of OpenStreetMap street and
+#' railway data around the river. Sparse OSM data, especially too few river
+#' crossings, may lead to failed delineation.
+#'
 #' The returned [`delineation`] class is a list wrapping objects of class
 #' [`sf::sfc_POLYGON`] or [`sf::sfc_MULTIPOLYGON`] which can be retrieved
 #' through subsetting and converted to other common spatial classes in typical
@@ -131,6 +135,19 @@ delineate <- function(
     # Set up the combined street and rail network for the delineation
     network_edges <- dplyr::bind_rows(osm$streets, osm$railways)
     network <- as_network(network_edges)
+    crossings <- get_intersecting_edges(network, osm$river_centerline)
+    crossings_clustered <- if (nrow(crossings) == 0) {
+      sf::st_geometry(crossings)
+    } else {
+      filter_clusters(crossings, osm$river_centerline)
+    }
+    # Too few river crossings may lead to failed corridor delineation.
+    if (length(crossings_clustered) < 2) {
+      stop(sprintf(
+        "Insufficient OSM data: %d river crossings found, but at least 2 are required.",
+        length(crossings_clustered)
+      ))
+    }
 
     # Run the corridor delineation on the spatial network
     delineations$corridor <- delineate_corridor(

--- a/R/delineate.R
+++ b/R/delineate.R
@@ -23,14 +23,14 @@ NULL
 #' delineation, corridor segmentation and/or riverspace delineation as indicated
 #' by the user.
 #'
-#' Corridor delineation depends on the availability of OpenStreetMap street and
-#' railway data around the river. Sparse OSM data, especially too few river
-#' crossings, may lead to failed delineation.
-#'
 #' The returned [`delineation`] class is a list wrapping objects of class
 #' [`sf::sfc_POLYGON`] or [`sf::sfc_MULTIPOLYGON`] which can be retrieved
 #' through subsetting and converted to other common spatial classes in typical
 #' `sf`- or `terra`-based workflows.
+#'
+#' Corridor delineation depends on the availability of OpenStreetMap street and
+#' railway data around the river. Sparse OSM data, especially too few river
+#' crossings, may lead to failed delineation.
 #'
 #' @param aoi A list of delineation parameters for an area of interest, namely
 #'   `$city_name`, `$river_name`, `$crs`, `$network_buffer`, `$dem_buffer`, and

--- a/R/delineate.R
+++ b/R/delineate.R
@@ -145,10 +145,10 @@ delineate <- function(
     if (length(crossings_clustered) < 2) {
       stop(sprintf(
         paste(
-          "Insufficient OSM data: %d river crossings found,",
-          "but at least 2 are required."
+          "Corridor delineation is not possible with %s.",
+          "At least 2 are required."
         ),
-        length(crossings_clustered)
+        ifelse(length(crossings_clustered) == 0, "no crossings", "1 crossing")
       ))
     }
 

--- a/man/delineate.Rd
+++ b/man/delineate.Rd
@@ -76,6 +76,10 @@ The returned \code{\link{delineation}} class is a list wrapping objects of class
 \code{\link[sf:sfc]{sf::sfc_POLYGON}} or \code{\link[sf:sfc]{sf::sfc_MULTIPOLYGON}} which can be retrieved
 through subsetting and converted to other common spatial classes in typical
 \code{sf}- or \code{terra}-based workflows.
+
+Corridor delineation depends on the availability of OpenStreetMap street and
+railway data around the river. Sparse OSM data, especially too few river
+crossings, may lead to failed delineation.
 }
 \examples{
 \dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/tests/testthat/test-delineate.R
+++ b/tests/testthat/test-delineate.R
@@ -87,6 +87,25 @@ test_that("Error is raised when OSM spatial network data is missing", {
                "Spatial network \\(streets, railways\\) data is not available")
 })
 
+test_that("Error is raised when fewer than two river crossings are found", {
+  osm <- test_osm
+  osm$railways <- test_osm$railways[0, ]
+  osm$streets <- test_osm$streets[1, ]
+  expect_error(
+    delineate(aoi, osm, corridor_init = 1000) |>
+      suppressWarnings(),
+    "Corridor delineation is not possible with no crossings"
+  )
+  osm$streets <- test_osm$streets[2, ]
+  expect_error(
+    delineate(aoi, osm, corridor_init = 1000) |>
+      suppressWarnings(),
+    "Corridor delineation is not possible with 1 crossing"
+  )
+  expect_no_error(delineate(aoi, test_osm, corridor_init = 1000) |>
+                    suppressWarnings())
+})
+
 test_that("Error is raised when buildings data is missing for riverspace delineation", {  # nolint
   osm_without_buildings <- test_osm
   osm_without_buildings$aoi_buildings <- NULL

--- a/vignettes/vig_05-corridor-delineation.Rmd
+++ b/vignettes/vig_05-corridor-delineation.Rmd
@@ -22,6 +22,8 @@ bucharest_dem <- get_dem_example_data()
 
 In this notebook we explore how to delineate an urban river corridor using river Dâmbovița in Bucharest, Romania. We will use OpenStreetMap (OSM) data, first from the Overpass API and then from a local file.
 
+Corridor delineation depends on the availability of OpenStreetMap street and railway data around the river. Sparse OSM data, especially too few river crossings, may lead to failed delineation.
+
 
 ``` r
 city_name <- "Bucharest"

--- a/vignettes/vig_05-corridor-delineation.Rmd.orig
+++ b/vignettes/vig_05-corridor-delineation.Rmd.orig
@@ -29,6 +29,8 @@ bucharest_dem <- get_dem_example_data()
 
 In this notebook we explore how to delineate an urban river corridor using river Dâmbovița in Bucharest, Romania. We will use OpenStreetMap (OSM) data, first from the Overpass API and then from a local file.
 
+Corridor delineation depends on the availability of OpenStreetMap street and railway data around the river. Sparse OSM data, especially too few river crossings, may lead to failed delineation.
+
 ```{r variables}
 city_name <- "Bucharest"
 river_name <- "Dâmbovița"


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Before submitting a Pull Request, please ensure you've read the rcrisp
[Contributing Guide](https://cityriverspaces.github.io/rcrisp/CONTRIBUTING.html)
and [Code of Conduct](https://cityriverspaces.github.io/rcrisp/CODE_OF_CONDUCT.html)
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [x] Documentation Update

## Description

Adds a check in `delineate()` for insufficient OSM crossing data. If fewer than 2 clustered river crossings are found, corridor delineation now stops with a clear error message.

Also documents that sparse OSM street/rail data may cause corridor delineation to fail.

## Related Issues

<!--
See [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related Issue #392 
- Closes #392 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [ ] Yes
